### PR TITLE
Add github repo link/install instructions for the dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,26 @@ Using pre-made configurations from [nvim-lspconfig](https://github.com/neovim/nv
 
 ## Installation
 #### Dependencies
-Make sure you have [`jq`](https://github.com/stedolan/jq), `curl`, `npm`, `gzip`, and `unzip` installed.
+Make sure you have [`jq`](https://github.com/stedolan/jq), [`curl`](https://github.com/curl/curl), [`npm`](https://github.com/npm/cli), [`gzip`](https://github.com/nicklockwood/GZIP), and [`unzip`]() installed.
+
+##### Install instructions for dependencies
+instructions for jq, curl, npm and gzip are given in their github repo
+
+```bash
+# unzip
+
+# For Arch or arch-based linux distros
+❯ sudo pacman -S unzip
+
+# Debian / Ubuntu based linux distros
+❯ sudo apt install unzip
+
+# MacoS
+❯ brew install unzip
+
+# Windows
+❯ choco install unzip
+```
 
 - [Packer](https://github.com/wbthomason/packer.nvim)
 ```lua


### PR DESCRIPTION
Hi,
I've seen these embedded links in lots of READMEs in github, and I felt like this repo needed it too, so... yeah.

(ignore the first commit, I didn't know if it was gonna work so I just tested it, I'm a newbie with markdown)
Thanks